### PR TITLE
docs: add OpenAI Assistants API deprecation notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A standalone Python client for calling Microsoft Fabric Data Agents from outside
 ⚠️This is in Preview and API can change until GA.
 
 > [!IMPORTANT]
-> The code in this repository uses the OpenAI Assistants API (`beta.assistants`, `beta.threads`, `beta.threads.runs`), which [OpenAI has deprecated](https://platform.openai.com/docs/assistants/migration). The current code continues to work until **August 26, 2026**, but plan to migrate to the [Fabric Data Agent MCP server](https://learn.microsoft.com/en-us/fabric/data-science/data-agent-mcp-server) before this date.
+> The code in this repository uses the OpenAI Assistants API (`beta.assistants`, `beta.threads`, `beta.threads.runs`), which [OpenAI has scheduled to be deprecated](https://platform.openai.com/docs/assistants/migration). The current code continues to work until **August 26, 2026**, but plan to migrate to the [Fabric Data Agent MCP server](https://learn.microsoft.com/en-us/fabric/data-science/data-agent-mcp-server) before this date.
 
 ## Overview
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@ A standalone Python client for calling Microsoft Fabric Data Agents from outside
 
 ⚠️This is in Preview and API can change until GA.
 
+> [!IMPORTANT]
+> The code in this repository uses the OpenAI Assistants API (`beta.assistants`, `beta.threads`, `beta.threads.runs`), which [OpenAI has deprecated](https://platform.openai.com/docs/assistants/migration). The current code continues to work until **August 26, 2026**, but plan to migrate to the [Fabric Data Agent MCP server](https://learn.microsoft.com/en-us/fabric/data-science/data-agent-mcp-server) before this date.
+
 ## Overview
 
 This client enables you to interact with your Microsoft Fabric Data Agents from external applications, scripts, or environments. It handles Azure authentication, token management, and provides a simple interface for asking questions to your data agents. Feel free to inspect the example usage for sample client code.


### PR DESCRIPTION
## Summary

This client relies on the OpenAI Assistants API (`beta.assistants`, `beta.threads`, `beta.threads.runs`), which [OpenAI has scheduled to be deprecated](https://platform.openai.com/docs/assistants/migration). This PR adds a prominent notice near the top of the README so users are aware of the deprecation and the migration path.

## What changed

Added an `> [!IMPORTANT]` callout right after the Preview warning:

> The code in this repository uses the OpenAI Assistants API (`beta.assistants`, `beta.threads`, `beta.threads.runs`), which OpenAI has scheduled to be deprecated. The current code continues to work until **August 26, 2026**, but plan to migrate to the [Fabric Data Agent MCP server](https://learn.microsoft.com/en-us/fabric/data-science/data-agent-mcp-server) before this date.

## Notes

- Documentation-only change; no code impact.
- Please adjust wording or links as needed for house style.